### PR TITLE
fix: there was a regression on get-gke-credentials version in the latest tag

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -107,7 +107,7 @@ runs:
 
     - name: 'GCloud get GKE credentials'
       id: 'get-credentials'
-      uses: google-github-actions/get-gke-credentials@v0
+      uses: google-github-actions/get-gke-credentials@v2
       with:
         project_id: ${{ env.PROJECT_ID }}
         cluster_name: ${{ env.CLUSTER }}


### PR DESCRIPTION
Fixes a regression on the get-gke-credentials action version in the latest tag.
I could spot a `deprecation` error on MonsieurMarguerite's deploy workflow outputs because the latest `1.0.7-beta` tag is pointing to `google-github-actions/get-gke-credentials@v0` instead of `google-github-actions/get-gke-credentials@v2`.